### PR TITLE
fix: correct pointer receiver method call edge generation

### DIFF
--- a/internal/analyzer/relationship_analyzer.go
+++ b/internal/analyzer/relationship_analyzer.go
@@ -441,8 +441,10 @@ func (r *RelationshipAnalyzer) resolveCallTarget(pkg *packages.Package, call *as
 				receiverType := types.TypeString(recv, nil)
 				switch recv.(type) {
 				case *types.Named:
-					if !sel.Indirect() {
-						receiverType = "*" + receiverType
+					if sig, _ := method.Type().(*types.Signature); sig != nil {
+						if _, isPtr := deref(sig.Recv().Type()); isPtr {
+							receiverType = "*" + receiverType
+						}
 					}
 				}
 
@@ -1119,3 +1121,15 @@ func (r *RelationshipAnalyzer) AnalyzeTypeUsage(pkg *packages.Package, sourceID 
 // analyzeFieldShadowing removed - unused after shadow detection removal
 
 // checkStructFieldShadowing removed - unused after shadow detection removal
+
+// deref safely dereferences a type and returns whether it was a pointer
+func deref(typ types.Type) (types.Type, bool) {
+	if p, _ := types.Unalias(typ).(*types.Pointer); p != nil {
+		// p.base should never be nil, but be conservative
+		if p.Elem() == nil {
+			return types.Typ[types.Invalid], true
+		}
+		return p.Elem(), true
+	}
+	return typ, false
+}

--- a/internal/analyzer/testdata/edges/pointer_receiver/pointer_receiver.go
+++ b/internal/analyzer/testdata/edges/pointer_receiver/pointer_receiver.go
@@ -66,3 +66,25 @@ func TestValueCall() {
 	writer := BasicFileWriter{name: "test"}
 	writer.Write([]byte("value"))
 }
+
+// Test case for value receiver method (the regression case discovered by @hxiaodon)
+type AnotherFileWriter struct {
+	name string
+}
+
+// Value receiver method (not pointer)
+func (f AnotherFileWriter) Write(data []byte) error {
+	return nil
+}
+
+func TestValueReceiverMethod() {
+	// Create a value and call value receiver method
+	writer := AnotherFileWriter{name: "test"}
+	writer.Write([]byte("value"))  // Should create edge to AnotherFileWriter.Write (NOT *AnotherFileWriter.Write)
+}
+
+func TestPointerCallValueReceiver() {
+	// Create a pointer and call value receiver method
+	writer := &AnotherFileWriter{name: "test"}
+	writer.Write([]byte("value"))  // Should still create edge to AnotherFileWriter.Write (NOT *AnotherFileWriter.Write)
+}


### PR DESCRIPTION
Fixes GitHub issue #3 by properly handling pointer receiver methods when called by struct values.

This addresses the core issue where call edges were not being correctly constructed for pointer receiver methods. Go automatically takes the address of a value when calling a pointer method (e.g., writer.Write() becomes (&writer).Write()), and our edge generation needed to reflect this.

Key changes:
- Replace sel.Indirect() check with proper method signature inspection
- Use types.Signature to determine if method receiver is actually a pointer
- Add deref() helper function for safe pointer type dereferencing
- Correctly prefix pointer receiver methods with '*' in node IDs
- Ensure value receiver methods do NOT get '*' prefix (fixes regression)

Test improvements:
- Add comprehensive test cases for both pointer and value receivers
- Include regression tests to prevent value receiver methods getting '*' prefix
- Test cases cover: value->pointer method, pointer->pointer method, value->value method, pointer->value method

This fix ensures that:
1. BasicFileWriter.Write (pointer receiver) gets ID: *BasicFileWriter.Write ✓
2. AnotherFileWriter.Write (value receiver) gets ID: AnotherFileWriter.Write ✓
3. Call edges correctly target the appropriate method signatures ✓

Co-authored-by: @hxiaodon (original fix suggestion and regression detection)